### PR TITLE
Add info to prevent BuiltKit make error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ In Docker Desktop, go to `Preferences > Extensions` and check `Enable Docker Ext
 
 Since this Docker Extensions hasn't been yet published, it's required to build and deploy it locally from source code.
 
-Run the following command to build and install the local extension:
+Make sure that [Docker Desktop](https://www.docker.com/products/docker-desktop/) is running in the background. 
+
+Then run the following command to build and install the local extension:
 
 ```sh
 make install-extension


### PR DESCRIPTION
If Docker Desktop is not started, you face the following error running "make install-extension"

```
alfresco-docker-extension git:(main) make install-extension docker build --tag=angelborroy/alfresco-extension:latest . Sending build context to Docker daemon  1.768MB
Step 1/14 : FROM node:17.7-alpine3.14 AS client-builder
 ---> e9a88f2d8eff
Step 2/14 : WORKDIR /ui
 ---> Using cache
 ---> 45fee6926bdb
Step 3/14 : COPY ui/package.json /ui/package.json
 ---> Using cache
 ---> a2e7c4f619b1
Step 4/14 : COPY ui/package-lock.json /ui/package-lock.json
 ---> Using cache
 ---> 911c98564e0e
Step 5/14 : RUN --mount=type=cache,target=/usr/src/app/.npm     npm set cache /usr/src/app/.npm &&     npm ci
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
make: *** [Makefile:10: build-extension] Fehler 1
```

Added information to documenation to prevent this error.